### PR TITLE
Feature/trigger builds via api (#10)

### DIFF
--- a/src/circleci-base/scripts/trigger-build-api.sh
+++ b/src/circleci-base/scripts/trigger-build-api.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+set -eu
+
+repo=$1
+user=greenpeace
+branch=${2:-develop}
+
+json=$(jq -n \
+  --arg VAL "$branch" \
+'{
+	"branch": $VAL
+}')
+
+
+curl \
+  --header "Content-Type: application/json" \
+  -d "$json" \
+  -u "${CIRCLE_TOKEN}:" \
+  -X POST \
+  "https://circleci.com/api/v1.1/project/github/${user}/${repo}/build"


### PR DESCRIPTION
* Script to trigger the builds via API instead of git commits. 

Requires a CIRCLE_TOKEN variable to exists in the repo that calls it. Will have to add it to the planet4-base-fork