### PR TITLE
Remove merged flag when creating new release branch

### DIFF
--- a/src/circleci-base/scripts/release-prepare-nro.sh
+++ b/src/circleci-base/scripts/release-prepare-nro.sh
@@ -31,7 +31,6 @@ echo "-- 1.0   Before the first if"
 if release-start.sh "$new_release"
 then
   echo "-- 1.1   New release branch created: release/$new_release"
-  merged=true
 else
   echo "-- 1.1   Release branch release/$new_release already exists"
   # Release branch already exists


### PR DESCRIPTION
Remove setting merged flag when creating new release branch so that it creates a new commit with the modifications (if any) and won't try to amend the latest commit
https://github.com/greenpeace/planet4-circleci/blob/master/src/circleci-base/scripts/release-prepare-nro.sh#L68

Failed job:
https://circleci.com/gh/greenpeace/planet4-international/1656