### PR TITLE
Feature/makefile tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,94 +27,20 @@ jobs:
       - run: activate-gcloud-account.sh
       - run: gcloud auth configure-docker
       - run: make build
-      - run: make -j2 push
+      - run: make test
+      - run: make -j push
       - run:
           name: Notify failure
           when: on_fail
           command: notify-job-failure.sh
+      - store_test_results:
+          path: /home/circleci/app/test/logs
+      - store_artifacts:
+          path: /home/circleci/app/test/logs
       - persist_to_workspace:
           root: /tmp/workspace
           paths:
             - var
-
-  test:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - run:
-          name: Setup test results
-          command: |
-            mkdir -p /tmp/test-results
-      - run:
-          name: Pull new image
-          command: |
-            docker pull gcr.io/${GOOGLE_PROJECT_ID}/circleci-base:build-$(cat /tmp/workspace/var/circle-build-num)
-      - run:
-          name: Test commit message tag promotion
-          command: |
-            docker run --rm gcr.io/${GOOGLE_PROJECT_ID}/circleci-base:build-$(cat /tmp/workspace/var/circle-build-num) git-new-version.sh "[ci tag v1.2.3-test]" >/tmp/test-results/git_new_version_detect_1.txt
-            grep "v1.2.3-test" /tmp/test-results/git_new_version_detect_1.txt
-            docker run --rm gcr.io/${GOOGLE_PROJECT_ID}/circleci-base:build-$(cat /tmp/workspace/var/circle-build-num) git-new-version.sh "[ci promote v1.2.3]" >/tmp/test-results/git_new_version_detect_2.txt
-            grep "v1.2.3" /tmp/test-results/git_new_version_detect_2.txt
-            docker run --rm gcr.io/${GOOGLE_PROJECT_ID}/circleci-base:build-$(cat /tmp/workspace/var/circle-build-num) git-new-version.sh "[ci release 10.20.30a]" >/tmp/test-results/git_new_version_detect_3.txt
-            grep "10.20.30a" /tmp/test-results/git_new_version_detect_3.txt
-      - run:
-          name: Test Silver Searcher
-          command: |
-            docker run --rm gcr.io/${GOOGLE_PROJECT_ID}/circleci-base:build-$(cat /tmp/workspace/var/circle-build-num) ag --version >/tmp/test-results/ag_version.txt
-            grep -E "ag version\s[0-9.]{1,}" /tmp/test-results/ag_version.txt
-      - run:
-          name: Test hadolint
-          command: |
-            docker run --rm gcr.io/${GOOGLE_PROJECT_ID}/circleci-base:build-$(cat /tmp/workspace/var/circle-build-num) hadolint --version >/tmp/test-results/hadolint_version.txt
-            grep -E "Haskell Dockerfile Linter\sv[0-9.]{1,}" /tmp/test-results/hadolint_version.txt
-      - run:
-          name: Test yamllint
-          command: |
-            docker run --rm gcr.io/${GOOGLE_PROJECT_ID}/circleci-base:build-$(cat /tmp/workspace/var/circle-build-num) yamllint --version 2>/tmp/test-results/yamllint_version.txt
-            grep -E "yamllint\s[0-9.]{1,}" /tmp/test-results/yamllint_version.txt
-      - run:
-          name: Test PHP
-          command: |
-            docker run --rm gcr.io/${GOOGLE_PROJECT_ID}/circleci-base:build-$(cat /tmp/workspace/var/circle-build-num) php -v > /tmp/test-results/php_version.txt
-            docker run --rm gcr.io/${GOOGLE_PROJECT_ID}/circleci-base:build-$(cat /tmp/workspace/var/circle-build-num) php -r "phpinfo();" > /tmp/test-results/php_info.txt
-            grep -E "PHP\s[0-9.]{1,}" /tmp/test-results/php_version.txt
-      - run:
-          name: Test Composer
-          command: |
-            docker run --rm gcr.io/${GOOGLE_PROJECT_ID}/circleci-base:build-$(cat /tmp/workspace/var/circle-build-num) composer --version > /tmp/test-results/composer_version.txt
-            grep -E 'Composer version [0-9.]{1,}' /tmp/test-results/composer_version.txt
-      - run:
-          name: Test gcloud
-          command: |
-            docker run --rm gcr.io/${GOOGLE_PROJECT_ID}/circleci-base:build-$(cat /tmp/workspace/var/circle-build-num) gcloud -v > /tmp/test-results/gcloud_version.txt
-            grep -E 'Google Cloud SDK [0-9.]{1,}' /tmp/test-results/gcloud_version.txt
-            grep -E 'kubectl [0-9.]{1,}' /tmp/test-results/gcloud_version.txt
-            gcloud config set project ${GOOGLE_PROJECT_ID}
-            grep $GOOGLE_PROJECT_ID <<< $(gcloud config list)
-      - run:
-          name: Test cloud_sql_proxy
-          command: |
-            docker run --rm gcr.io/${GOOGLE_PROJECT_ID}/circleci-base:build-$(cat /tmp/workspace/var/circle-build-num) cloud_sql_proxy --version > /tmp/test-results/cloud_sql_proxy.txt
-            grep -E 'Cloud SQL Proxy: version [0-9.]{1,}' /tmp/test-results/cloud_sql_proxy.txt
-      - run:
-          name: Test mysqldump
-          command: |
-            docker run --rm gcr.io/${GOOGLE_PROJECT_ID}/circleci-base:build-$(cat /tmp/workspace/var/circle-build-num) mysqldump --version > /tmp/test-results/mysqldump.txt
-            grep -E 'mysqldump  Ver [0-9.]{1,}' /tmp/test-results/mysqldump.txt
-      - run:
-          name: Notify failure
-          when: on_fail
-          command: TYPE="Tests" notify-job-failure.sh
-      - run:
-          name: Notify success
-          command: TYPE="Tests" notify-job-success.sh
-      - checkout
-      - store_test_results:
-          path: /tmp/test-results
 
   notify-promote:
     <<: *defaults
@@ -196,24 +122,17 @@ workflows:
           filters:
             branches:
               ignore: master
-      - test:
-          context: org-global
-          requires:
-            - build
-          filters:
-            branches:
-              ignore: master
       - hold-promote:
           type: approval
           requires:
-            - test
+            - build
           filters:
             branches:
               only: develop
       - notify-promote:
           context: org-global
           requires:
-            - test
+            - build
           filters:
             branches:
               only: develop
@@ -229,18 +148,14 @@ workflows:
     jobs:
       - build:
           <<: *tag_common
-      - test:
-          <<: *tag_common
-          requires:
-            - build
       - deploy:
           <<: *tag_common
           requires:
-            - test
+            - build
       - update-tag:
           <<: *tag_common
           requires:
-            - test
+            - build
       - trigger:
           <<: *tag_common
           requires:

--- a/test/.env.bash
+++ b/test/.env.bash
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# shellcheck disable=2034
+set -a
+
+VERSION_REGEX="v?[[:digit:]]+\\.[[:digit:]]+"
+
+[ -z "${BUILD_IMAGE+x}" ] && BUILD_IMAGE=gcr.io/planet-4-151612/circleci-base
+[ -z "${BUILD_TAG+x}" ] && BUILD_TAG=build-$(uname -n | tr '[:upper:]' '[:lower:]' | sed 's/[^a-zA-Z0-9._-]/-/g')
+
+BATS_IMAGE="${BUILD_IMAGE}:${BUILD_TAG}"
+
+FOLDER=${CIRCLE_PROJECT_REPONAME:-$(basename "$(git rev-parse --show-toplevel)")}
+
+function setup {
+  set -e
+  docker images | grep -Eq "^${BUILD_IMAGE}\\s+${BUILD_TAG}" || {
+    >&2 echo "ERROR: Image not found: ${BATS_IMAGE}"
+    >&2 echo "Perhaps run make first?"
+    exit 1
+  }
+}
+#
+# function teardown {
+#   store_output
+# }
+
+function finish {
+  { set +ex; } 2>/dev/null
+}
+trap finish EXIT
+
+function warning {
+  >&2 echo "WARNING: $1"
+}
+
+function error {
+  fatal "$1"
+}
+
+function fatal {
+  >&2 echo "ERROR: $1"
+  exit 1
+}
+
+function run_docker_binary() {
+  image="$1"
+  shift
+  args=("$@")
+  docker run --rm -ti "${image}" "${args[@]}"
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,36 @@
+BATS := bats
+TAP := tap
+XML := xml
+
+LOGS := logs
+
+TEST_FILES := $(wildcard *.$(BATS))
+TAP_FILES := $(patsubst %.$(BATS), $(LOGS)/%.$(TAP), $(TEST_FILES))
+XML_FILES := $(patsubst %.$(BATS), $(LOGS)/%.$(XML), $(TEST_FILES))
+
+# NPROCS = $(shell grep -c 'processor' /proc/cpuinfo 2>/dev/null)
+# ifeq ($(strip $(NPROCS)),)
+# NPROCS = $(shell sysctl hw.ncpu  | grep -o '[0-9]\+')
+# endif
+#
+# MAKEFLAGS += -j$(NPROCS)
+
+.PHONY: all clean
+
+all: $(LOGS) $(TAP_FILES) $(XML_FILES)
+
+clean:
+		@rm -f $(LOGS)/*.$(TAP) $(LOGS)/*.$(XML)
+
+status:
+		@! ag 'not ok' $(LOGS)/
+		@echo 'ok'
+
+$(LOGS):
+		mkdir -p $(LOGS)
+
+$(LOGS)/%.$(TAP): %.$(BATS)
+		-@bats --tap $^ | tee $@
+
+$(LOGS)/%.$(XML): $(LOGS)/%.$(TAP)
+		@tap-xunit --package="circleci.base.$(shell echo $@ | cut -d/ -f2 | cut -d. -f1 )" < $^ > $@

--- a/test/ag.bats
+++ b/test/ag.bats
@@ -1,0 +1,11 @@
+#!/usr/bin/env bats
+set -eu
+
+load .env
+
+@test "$(basename "${BATS_SOURCE//.bats/}") --version" {
+  expected="ag version\\s$VERSION_REGEX"
+  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" --version
+  [ "$status" -eq 0 ]
+  printf '%s' "$output" | grep -Eq "$expected"
+}

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -1,0 +1,10 @@
+#!/usr/bin/env bats
+set -eu
+
+load .env
+
+@test "$(basename "${BATS_SOURCE//.bats/}") --version" {
+  run run_docker_binary "$BATS_IMAGE" bats --version
+  [ $status -eq 0 ]
+  printf '%s' "$output" | grep -Eq "Bats $VERSION_REGEX"
+}

--- a/test/composer.bats
+++ b/test/composer.bats
@@ -1,0 +1,11 @@
+#!/usr/bin/env bats
+set -eu
+
+load .env
+
+@test "$(basename "${BATS_SOURCE//.bats/}") --version" {
+  expected="Composer version\\s$VERSION_REGEX"
+  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" --no-ansi --version
+  [ $status -eq 0 ]
+  printf '%s' "$output" | grep -Eq "$expected"
+}

--- a/test/gcloud.bats
+++ b/test/gcloud.bats
@@ -1,0 +1,13 @@
+#!/usr/bin/env bats
+set -eu
+
+load .env
+
+@test "$(basename "${BATS_SOURCE//.bats/}") --version" {
+  expected="Google Cloud SDK\\s$VERSION_REGEX"
+  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" --version
+  [ $status -eq 0 ]
+  printf '%s' "$output" | grep -Eq "Google Cloud SDK\\s$VERSION_REGEX"
+  printf '%s' "$output" | grep -Eq "kubectl\\s$VERSION_REGEX"
+  printf '%s' "$output" | grep -Eq "cloud_sql_proxy"
+}

--- a/test/git-new-version.sh.bats
+++ b/test/git-new-version.sh.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+set -eu
+
+load .env
+
+@test "$(basename "${BATS_SOURCE//.bats/}") [ci tag v1.2.3-test]" {
+  v=v1.2.3-test
+  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" "[ci tag $v]"
+  [ $status -eq 0 ]
+  printf '%s' "$output" | grep -Eq "$v"
+  >&2 printf '%s' "$output"
+}
+
+@test "$(basename "${BATS_SOURCE//.bats/}") [ci tag 1.2.3]" {
+  v=1.2.3
+  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" "[ci tag $v]"
+  [ $status -eq 0 ]
+  printf '%s' "$output" | grep -Eq "$v"
+  printf '%s' "$output"
+}
+
+@test "$(basename "${BATS_SOURCE//.bats/}") [ci tag 0.20.30a-build42]" {
+  v=0.20.30a-build42
+  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" "'[ci tag $v]'"
+  [ $status -eq 0 ]
+  printf '%s' "$output" | grep -Eq "$v"
+  printf '%s' "$output"
+}
+
+@test "$(basename "${BATS_SOURCE//.bats/}") [ci release 1.2.3]" {
+  v=1.2.3
+  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" "[ci tag $v]"
+  [ $status -eq 0 ]
+  printf '%s' "$output" | grep -Eq "$v"
+  >&2 printf '%s' "$output"
+}
+
+@test "$(basename "${BATS_SOURCE//.bats/}") [ci promote 1.2.3]" {
+  v=1.2.3
+  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" "[ci promote $v]"
+  [ $status -eq 0 ]
+  printf '%s' "$output" | grep -Eq "$v"
+  >&2 printf '%s' "$output"
+}
+
+@test "[ERROR] $(basename "${BATS_SOURCE//.bats/}") [ci error 1.2.3]" {
+  ci="ci error 1.2.3"
+  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" "[$ci]"
+  [ $status -eq 1 ]
+}
+
+@test "[ERROR] $(basename "${BATS_SOURCE//.bats/}") [ci error blahblah]" {
+  ci="ci error blahblah"
+  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" "[$ci]"
+  [ $status -eq 1 ]
+  >&2 printf '%s' "$output"
+}
+
+@test "[ERROR] $(basename "${BATS_SOURCE//.bats/}") [ci tag blahblah]" {
+  ci="ci tag blahblah"
+  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" "[$ci]"
+  [ $status -eq 1 ]
+}

--- a/test/mysqldump.bats
+++ b/test/mysqldump.bats
@@ -1,0 +1,11 @@
+#!/usr/bin/env bats
+set -eu
+
+load .env
+
+@test "$(basename "${BATS_SOURCE//.bats/}") --version" {
+  expected="mysqldump\\s+Ver\\s+$VERSION_REGEX"
+  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" --version
+  [ $status -eq 0 ]
+  printf '%s' "$output" | grep -Eq "$expected"
+}

--- a/test/php.bats
+++ b/test/php.bats
@@ -1,0 +1,11 @@
+#!/usr/bin/env bats
+set -eu
+
+load .env
+
+@test "$(basename "${BATS_SOURCE//.bats/}") --version" {
+  expected="PHP\\s$VERSION_REGEX"
+  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" --version
+  [ $status -eq 0 ]
+  printf '%s' "$output" | grep -Eq "$expected"
+}

--- a/test/yamllint.bats
+++ b/test/yamllint.bats
@@ -1,0 +1,11 @@
+#!/usr/bin/env bats
+set -eu
+
+load .env
+
+@test "$(basename "${BATS_SOURCE//.bats/}") --version" {
+  expected="yamllint\\s$VERSION_REGEX"
+  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" --version
+  [ $status -eq 0 ]
+  printf '%s' "$output" | grep -Eq "$expected"
+}


### PR DESCRIPTION
Run unit tests with BATS from the Makefile

Runs locally or in CI, supports parallel execution with `MAKEFLAGS=-j make test` but mangles screen output a little.

Simple framework for expanding and adding new tests, just add a file in test/thingy.bats and execute scripts to verify funcitonality.  In particular, look at https://github.com/greenpeace/planet4-circleci/blob/4fc33881ccb84425785e5136bdce7b1085499123/test/git-new-version.sh.bats for an example implementation of verifying script output from input.

Ideally, more functionality will be tested in future...