### PR TITLE
PLANET-3241 nl-plugin-blocks does not go to tagged versions on gp-nl releases

### DIFF
--- a/src/circleci-base/scripts/pin-composer-versions.sh
+++ b/src/circleci-base/scripts/pin-composer-versions.sh
@@ -6,7 +6,6 @@ composer=${1:-${COMPOSER:-composer-local.json}}
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp/}$(basename "$0").XXXXXXXXXXXX")
 
 BLACKLIST=( \
-  greenpeace/planet4-gpnl-plugin-blocks \
   greenpeace/planet4-master-theme \
   greenpeace/planet4-plugin-blocks \
   greenpeace/planet4-plugin-engagingnetworks \


### PR DESCRIPTION
Remove gpnl-plugin-blocks from blacklisted repos

Tested on
https://circleci.com/gh/greenpeace/planet4-theia/81