### PR TITLE
PLANET-5141 Adapt script for new release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 ---
+version: 2.1
+
 defaults: &defaults
   environment:
     GOOGLE_PROJECT_ID: planet-4-151612
   docker:
     - image: greenpeaceinternational/circleci-base:develop
   working_directory: /home/circleci/app
-
-version: 2
 
 jobs:
   build:

--- a/src/circleci-base/scripts/merge-develop.sh
+++ b/src/circleci-base/scripts/merge-develop.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Description: Automatically merge develop branch to master on each commit
+
+GIT_COMMIT_MESSAGE=$(git --git-dir=/tmp/workspace/.git log --format=%B -n 1 "$CIRCLE_SHA1")
+if [[ $GIT_COMMIT_MESSAGE == *"[DEV]"* ]]; then
+  echo "Not merging. There a DEV prefix"
+  exit 0
+fi
+
+git config user.email "circleci-bot@greenpeace.org"
+git config user.name "CircleCI Bot"
+git config merge.ours.driver true
+
+commit_message=":robot: ${2:-Merge develop to master}"
+
+# Ensure master branch is up to date with origin
+git checkout master
+git reset --hard origin/master
+
+# Merge develop into master, with strategy ours
+git merge --strategy-option=ours --no-ff --no-edit develop -m "$commit_message"
+git push origin master
+
+exit 0

--- a/src/circleci-base/scripts/promote-to-production.sh
+++ b/src/circleci-base/scripts/promote-to-production.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ID="$1"
+echo "ID: ${ID}"
+
+url="https://circleci.com/api/v2/workflow/${ID}/job"
+
+# Get workflow details
+workflow=$(curl -s -u "${CIRCLE_TOKEN}": -X GET --header "Content-Type: application/json" "$url")
+
+# Get approval job id
+job_id=$(echo "$workflow" | jq -r '.items[] | select(.name=="hold-production") | .approval_request_id ')
+echo "JOB ID: ${job_id}"
+
+# Approve
+curl \
+  --header "Content-Type: application/json" \
+  -u "${CIRCLE_TOKEN}:" \
+  -X POST \
+  "https://circleci.com/api/v2/workflow/${ID}/approve/${job_id}"

--- a/src/circleci-base/scripts/trigger-build.sh
+++ b/src/circleci-base/scripts/trigger-build.sh
@@ -4,34 +4,33 @@ set -u
 repo=$1
 branch=${2:-develop}
 
-export TYPE="Trigger: $repo:$branch"
-
 dir=$(echo "$repo" | tr -dc 'a-zA-Z0-9' | head -n 1)
 
 rm -fr "$dir"
 mkdir "$dir"
 
-GIT_COMMIT_DESC=$(git --git-dir=/tmp/workspace/.git log --format=%B -n 1 "$CIRCLE_SHA1")
-if [[ $GIT_COMMIT_DESC == *"[DEV]"* ]]; then
-  GIT_PREFIX="[DEV]"
-elif [[ $GIT_COMMIT_DESC == *"[AUTO-PROCEED]"* ]]; then
-  GIT_PREFIX="[AUTO-PROCEED]"
+echo "Triggering $repo"
+
+GIT_COMMIT_MESSAGE=$(git --git-dir=/tmp/workspace/.git log --format=%B -n 1 "$CIRCLE_SHA1")
+if [[ $GIT_COMMIT_MESSAGE == *"[HOLD]"* ]]; then
+  GIT_PREFIX=" [HOLD]"
 else
   GIT_PREFIX=""
-fi;
+fi
 
 # Checkout dependent repository and trigger CI with empty commit.
-git clone "$repo" "$dir" && \
-  cd "$dir" && \
-  git config user.email "circleci-bot@greenpeace.org" && \
-  git config user.name "CircleCI Bot" && \
-  git config push.default simple && \
-  git checkout "$branch" && \
-  git commit --allow-empty -m ":robot: ${GIT_PREFIX} Build trigger from ${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} Build #${CIRCLE_BUILD_NUM}" -m "${CIRCLE_BUILD_URL}" && \
-  git push --force-with-lease --set-upstream origin "$branch" && \
-  notify-job-success.sh && \
-  exit 0
-
-# No bueno
-notify-job-failure.sh
-exit 1
+git clone "$repo" "$dir"
+cd "$dir" || exit 1
+git config user.email "circleci-bot@greenpeace.org"
+git config user.name "CircleCI Bot"
+git config push.default simple
+git checkout "$branch"
+if [ "$branch" == "develop" ]; then
+  git commit --allow-empty -m ":robot:${GIT_PREFIX} Trigger build #${CIRCLE_BUILD_NUM}" -m "${CIRCLE_BUILD_URL}"
+  git push origin "$branch"
+else
+  current_version=$(git describe --abbrev=0 --tags)
+  new_version=$(increment-version.sh "$current_version")
+  git tag -a "$new_version" -m "$new_version"
+  git push origin --tags
+fi

--- a/src/circleci-base/scripts/trigger-production.sh
+++ b/src/circleci-base/scripts/trigger-production.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -eu
+
+repo=$1
+user=greenpeace
+tag=$2
+
+json=$(jq -n \
+  --arg VAL "$tag" \
+  --arg RELEASE_STAGE "production" \
+'{
+    "tag": $VAL,
+    "parameters": {
+      "release_stage": $RELEASE_STAGE
+    }
+}')
+
+echo "Build: ${user}/${repo}@${tag}"
+
+curl \
+  --header "Content-Type: application/json" \
+  -d "$json" \
+  -u "${CIRCLE_TOKEN}:" \
+  -X POST \
+  "https://circleci.com/api/v2/project/github/${user}/${repo}/pipeline"


### PR DESCRIPTION
### Add news scripts for new release flow
- `merge-develop.sh`: Simple script to merge develop branch to master on `planet4-<nro>` repos. Mostly re-purposed existing scripts.
- `promote-to-production.sh`: Automatically approve the "Hold" job if all tests pass on staging.
- `trigger-production.sh`: Trigger the production pipeline through API when staging completes deployment.

### Adjust trigger-build script for new release flow
- Reverse promotion logic: auto-promote by default, use `[HOLD]` to block that.
- Commit on develop branch for develop.
- Push new tag for staging and production.

