### PR TITLE
Bump Trivy to v0.11.1

### DIFF
--- a/config.default
+++ b/config.default
@@ -37,7 +37,7 @@ SHFMT_VERSION=3.1.2
 TAP_XUNIT_VERSION=2.4.1
 
 # https://github.com/knqyf263/trivy/releases
-TRIVY_VERSION=0.9.1
+TRIVY_VERSION=0.11.1
 
 # https://pypi.org/project/yamllint/#history
 YAMLLINT_VERSION=1.23.0


### PR DESCRIPTION
Our current version is no longer available in Github, so this was failing.