### PR TITLE
Pin base docker image

### DIFF
--- a/config.default
+++ b/config.default
@@ -22,7 +22,7 @@ GOOGLE_SDK_VERSION=316.0.0
 HADOLINT_VERSION=1.18.0
 
 # https://github.com/helm/helm/releases
-HELM_VERSION=2.17
+HELM_VERSION=2.17.0
 
 # https://www.npmjs.com/package/junit-merge
 JUNIT_MERGE_VERSION=2.0.0

--- a/config.default
+++ b/config.default
@@ -10,24 +10,24 @@
 # Vendor application versions
 
 # https://www.npmjs.com/package/bats
-BATS_VERSION=1.1.0
+BATS_VERSION=1.2.0
 
 # https://github.com/petervanderdoes/gitflow-avh/releases
 GIT_FLOW_VERSION=1.12.3
 
 # https://cloud.google.com/sdk/docs/quickstart-linux
-GOOGLE_SDK_VERSION=299.0.0
+GOOGLE_SDK_VERSION=316.0.0
 
 # https://github.com/hadolint/hadolint/releases
 HADOLINT_VERSION=1.18.0
 
 # https://github.com/helm/helm/releases
-HELM_VERSION=2.16.9
+HELM_VERSION=2.17
 
 # https://www.npmjs.com/package/junit-merge
 JUNIT_MERGE_VERSION=2.0.0
 
-# https://shellcheck.storage.googleapis.com/index.html
+# https://github.com/koalaman/shellcheck
 SHELLCHECK_VERSION=0.7.1
 
 # https://github.com/mvdan/sh/releases
@@ -40,10 +40,10 @@ TAP_XUNIT_VERSION=2.4.1
 TRIVY_VERSION=0.11.1
 
 # https://pypi.org/project/yamllint/#history
-YAMLLINT_VERSION=1.23.0
+YAMLLINT_VERSION=1.25.0
 
 # https://pypi.org/project/yq/#history
-YQ_VERSION=2.10.1
+YQ_VERSION=2.11.1
 
 # =============================================================================
 

--- a/config.default
+++ b/config.default
@@ -37,7 +37,7 @@ SHFMT_VERSION=3.1.2
 TAP_XUNIT_VERSION=2.4.1
 
 # https://github.com/knqyf263/trivy/releases
-TRIVY_VERSION=0.11.1
+TRIVY_VERSION=0.14.0
 
 # https://pypi.org/project/yamllint/#history
 YAMLLINT_VERSION=1.25.0

--- a/config.default
+++ b/config.default
@@ -59,7 +59,7 @@ NAMESPACE=gcr.io
 
 # Upstream image
 BASE_IMAGE=php
-BASE_NAMESPACE=circleci
+BASE_NAMESPACE=cimg
 BASE_TAG=7.3.26-node
 
 # Vars left intentionally blank to inform get_var_array to rewrite these

--- a/config.default
+++ b/config.default
@@ -60,7 +60,7 @@ NAMESPACE=gcr.io
 # Upstream image
 BASE_IMAGE=php
 BASE_NAMESPACE=circleci
-BASE_TAG=7.3-node
+BASE_TAG=7.3.26-node
 
 # Vars left intentionally blank to inform get_var_array to rewrite these
 BRANCH_NAME=

--- a/src/circleci-base/scripts/changelog.sh
+++ b/src/circleci-base/scripts/changelog.sh
@@ -92,12 +92,12 @@ if [ "$total" -ne 0 ]; then
     if [ "$track" == "Infra" ]; then
       infra="$infra$ticket"
       infra_md="$infra_md$ticket_md"
-    elif [ "$issuetype" == "Task" ]; then
-      features="$features$ticket"
-      features_md="$features_md$ticket_md"
-    else
+    elif [ "$issuetype" == "Bug" ]; then
       bugs="$bugs$ticket"
       bugs_md="$bugs_md$ticket_md"
+    else
+      features="$features$ticket"
+      features_md="$features_md$ticket_md"
     fi
 
   done

--- a/src/circleci-base/templates/Dockerfile.in
+++ b/src/circleci-base/templates/Dockerfile.in
@@ -59,7 +59,7 @@ RUN echo "Hadolint v${HADOLINT_VERSION} ..." && \
     tar xf /tmp/shellcheck.tar.xz -C /tmp/ && \
     mv /tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck /usr/local/bin && \
     echo "Helm v${HELM_VERSION} ..." && \
-    curl -sS "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -o /tmp/helm.tar.gz && \
+    curl -sS "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -o /tmp/helm.tar.gz && \
     tar zxf /tmp/helm.tar.gz -C /tmp/ && \
     mv /tmp/linux-amd64/helm /usr/local/bin/helm && \
     echo "Trivy v${TRIVY_VERSION} ..." && \

--- a/src/circleci-base/templates/Dockerfile.in
+++ b/src/circleci-base/templates/Dockerfile.in
@@ -27,7 +27,7 @@ RUN apt-get update && \
     rm -rf /tmp/* && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install \
+RUN pip install --no-cache-dir \
       yamllint==${YAMLLINT_VERSION} \
       yq==${YQ_VERSION}
 

--- a/src/circleci-base/templates/Dockerfile.in
+++ b/src/circleci-base/templates/Dockerfile.in
@@ -16,9 +16,7 @@ RUN apt-get update && \
       gawk \
       gettext \
       default-mysql-client \
-      python-pip \
-      python-pkg-resources \
-      python-setuptools \
+      python3-pip \
       rsync \
       silversearcher-ag \
       vim \
@@ -27,7 +25,7 @@ RUN apt-get update && \
     rm -rf /tmp/* && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir \
+RUN pip3 install --no-cache-dir \
       yamllint==${YAMLLINT_VERSION} \
       yq==${YQ_VERSION}
 

--- a/test/ag.bats
+++ b/test/ag.bats
@@ -3,9 +3,9 @@ set -eu
 
 load .env
 
-@test "$(basename "${BATS_SOURCE//.bats/}") --version" {
+@test "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1) --version" {
   expected="ag version\\s$VERSION_REGEX"
-  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" --version
+  run run_docker_binary "$BATS_IMAGE" "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1)" --version
   [ "$status" -eq 0 ]
   printf '%s' "$output" | grep -Eq "$expected"
 }

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -3,7 +3,7 @@ set -eu
 
 load .env
 
-@test "$(basename "${BATS_SOURCE//.bats/}") --version" {
+@test "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1) --version" {
   run run_docker_binary "$BATS_IMAGE" bats --version
   [ $status -eq 0 ]
   printf '%s' "$output" | grep -Eq "Bats $VERSION_REGEX"

--- a/test/composer.bats
+++ b/test/composer.bats
@@ -3,9 +3,9 @@ set -eu
 
 load .env
 
-@test "$(basename "${BATS_SOURCE//.bats/}") --version" {
+@test "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1) --version" {
   expected="Composer version\\s$VERSION_REGEX"
-  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" --no-ansi --version
+  run run_docker_binary "$BATS_IMAGE" "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1)" --no-ansi --version
   [ $status -eq 0 ]
   printf '%s' "$output" | grep -Eq "$expected"
 }

--- a/test/gcloud.bats
+++ b/test/gcloud.bats
@@ -3,9 +3,9 @@ set -eu
 
 load .env
 
-@test "$(basename "${BATS_SOURCE//.bats/}") --version" {
+@test "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1) --version" {
   expected="Google Cloud SDK\\s$VERSION_REGEX"
-  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" --version
+  run run_docker_binary "$BATS_IMAGE" "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1)" --version
   [ $status -eq 0 ]
   printf '%s' "$output" | grep -Eq "Google Cloud SDK\\s$VERSION_REGEX"
   printf '%s' "$output" | grep -Eq "kubectl\\s$VERSION_REGEX"

--- a/test/git-new-version.sh.bats
+++ b/test/git-new-version.sh.bats
@@ -3,23 +3,23 @@ set -eu
 
 load .env
 
-@test "$(basename "${BATS_SOURCE//.bats/}") [ci tag v1.2.3-test]" {
+@test "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1).sh [ci tag v1.2.3-test]" {
   v=v1.2.3-test
-  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" "'[ci tag $v]'"
+  run run_docker_binary "$BATS_IMAGE" "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1).sh" "'[ci tag $v]'"
   [ $status -eq 0 ]
   printf '%s' "$output" | grep -Eq "$v"
   >&2 printf '%s' "$output"
 }
 
-@test "$(basename "${BATS_SOURCE//.bats/}") [ci tag 1.2.3]" {
+@test "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1).sh [ci tag 1.2.3]" {
   v=1.2.3
-  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" "'[ci tag $v]'"
+  run run_docker_binary "$BATS_IMAGE" "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1).sh" "'[ci tag $v]'"
   [ $status -eq 0 ]
   printf '%s' "$output" | grep -Eq "$v"
   printf '%s' "$output"
 }
 
-@test "$(basename "${BATS_SOURCE//.bats/}") Multiple semver strings: [ci tag v2.3.4-test]" {
+@test "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1).sh Multiple semver strings: [ci tag v2.3.4-test]" {
   v=v2.3.4-test
   string=$(cat <<EOF
 Test 0.1.2
@@ -28,57 +28,57 @@ Thing
 
 [ci tag $v]
 EOF)
-  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" $string
+  run run_docker_binary "$BATS_IMAGE" "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1).sh" $string
   [ $status -eq 0 ]
   printf '%s' "$output" | grep -Eq "$v"
   printf '%s' "$output"
 }
 
-@test "$(basename "${BATS_SOURCE//.bats/}") Release blah [ci tag 0.20.30a-build42]" {
+@test "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1).sh Release blah [ci tag 0.20.30a-build42]" {
   v=0.20.30a-build42
-  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" "'[ci tag $v]'"
+  run run_docker_binary "$BATS_IMAGE" "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1).sh" "'[ci tag $v]'"
   [ $status -eq 0 ]
   printf '%s' "$output" | grep -Eq "$v"
   printf '%s' "$output"
 }
 
-@test "$(basename "${BATS_SOURCE//.bats/}") [ci release 1.2.3]" {
+@test "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1).sh [ci release 1.2.3]" {
   v=1.2.3
-  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" "[ci tag $v]"
+  run run_docker_binary "$BATS_IMAGE" "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1).sh" "[ci tag $v]"
   [ $status -eq 0 ]
   printf '%s' "$output" | grep -Eq "$v"
   >&2 printf '%s' "$output"
 }
 
-@test "$(basename "${BATS_SOURCE//.bats/}") [ci promote 1.2.3]" {
+@test "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1).sh [ci promote 1.2.3]" {
   v=1.2.3
-  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" "[ci promote $v]"
+  run run_docker_binary "$BATS_IMAGE" "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1).sh" "[ci promote $v]"
   [ $status -eq 0 ]
   printf '%s' "$output" | grep -Eq "$v"
   >&2 printf '%s' "$output"
 }
 
-@test "$(basename "${BATS_SOURCE//.bats/}") [ci error 1.2.3]" {
+@test "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1).sh [ci error 1.2.3]" {
   ci="ci error 1.2.3"
-  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" "[$ci]"
+  run run_docker_binary "$BATS_IMAGE" "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1).sh" "[$ci]"
   [ $status -eq 0 ]
   v=v0.0.1
   printf '%s' "$output" | grep -Eq "$v"
   >&2 printf '%s' "$output"
 }
 
-@test "$(basename "${BATS_SOURCE//.bats/}") [ci error blahblah]" {
+@test "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1).sh [ci error blahblah]" {
   ci="ci error blahblah"
-  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" "[$ci]"
+  run run_docker_binary "$BATS_IMAGE" "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1).sh" "[$ci]"
   [ $status -eq 0 ]
   v=v0.0.1
   printf '%s' "$output" | grep -Eq "$v"
   >&2 printf '%s' "$output"
 }
 
-@test "$(basename "${BATS_SOURCE//.bats/}") [ci tag blahblah]" {
+@test "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1).sh [ci tag blahblah]" {
   ci="ci tag blahblah"
-  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" "[$ci]"
+  run run_docker_binary "$BATS_IMAGE" "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1).sh" "[$ci]"
   v=v0.0.1
   printf '%s' "$output" | grep -Eq "$v"
   >&2 printf '%s' "$output"

--- a/test/helm.bats
+++ b/test/helm.bats
@@ -3,9 +3,9 @@ set -eu
 
 load .env
 
-@test "$(basename "${BATS_SOURCE//.bats/}") version --client" {
+@test "$(basename "$BATS_TEST_FILENAME"| cut -d. -f1) version --client" {
   expected="v$VERSION_REGEX"
-  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" "version --client | cut -d'\"' -f2"
+  run run_docker_binary "$BATS_IMAGE" "$(basename "$BATS_TEST_FILENAME"| cut -d. -f1)" "version --client | cut -d'\"' -f2"
   [ "$status" -eq 0 ]
   printf '%s' "$output" | grep -Eq "$expected"
 }

--- a/test/kubectl.bats
+++ b/test/kubectl.bats
@@ -3,9 +3,9 @@ set -eu
 
 load .env
 
-@test "$(basename "${BATS_SOURCE//.bats/}") version --client --short" {
+@test "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1) version --client --short" {
   expected="^Client Version: v$VERSION_REGEX"
-  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" "version --client --short"
+  run run_docker_binary "$BATS_IMAGE" "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1)" "version --client --short"
   [ "$status" -eq 0 ]
   printf '%s' "$output" | grep -Eq "$expected"
 }

--- a/test/mysqldump.bats
+++ b/test/mysqldump.bats
@@ -3,9 +3,9 @@ set -eu
 
 load .env
 
-@test "$(basename "${BATS_SOURCE//.bats/}") --version" {
+@test "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1) --version" {
   expected="mysqldump\\s+Ver\\s+$VERSION_REGEX"
-  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" --version
+  run run_docker_binary "$BATS_IMAGE" "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1)" --version
   [ $status -eq 0 ]
   printf '%s' "$output" | grep -Eq "$expected"
 }

--- a/test/php.bats
+++ b/test/php.bats
@@ -3,9 +3,9 @@ set -eu
 
 load .env
 
-@test "$(basename "${BATS_SOURCE//.bats/}") --version" {
+@test "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1) --version" {
   expected="PHP\\s$VERSION_REGEX"
-  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" --version
+  run run_docker_binary "$BATS_IMAGE" "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1)" --version
   [ $status -eq 0 ]
   printf '%s' "$output" | grep -Eq "$expected"
 }

--- a/test/shfmt.bats
+++ b/test/shfmt.bats
@@ -3,9 +3,9 @@ set -eu
 
 load .env
 
-@test "$(basename "${BATS_SOURCE//.bats/}") --version" {
+@test "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1) --version" {
   expected="v$VERSION_REGEX"
-  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" --version
+  run run_docker_binary "$BATS_IMAGE" "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1)" --version
   [ "$status" -eq 0 ]
   printf '%s' "$output" | grep -Eq "$expected"
 }

--- a/test/trivy.bats
+++ b/test/trivy.bats
@@ -3,9 +3,9 @@ set -eu
 
 load .env
 
-@test "$(basename "${BATS_SOURCE//.bats/}") --version" {
+@test "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1) --version" {
   expected="Version: $VERSION_REGEX"
-  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" --version
+  run run_docker_binary "$BATS_IMAGE" "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1)" --version
   [ "$status" -eq 0 ]
   printf '%s' "$output" | grep -Eq "$expected"
 }

--- a/test/update-build-numbers.sh.bats
+++ b/test/update-build-numbers.sh.bats
@@ -3,9 +3,9 @@ set -eu
 
 load .env
 
-@test "$(basename "${BATS_SOURCE//.bats/}") -h" {
-  expected="Usage: $(basename "${BATS_SOURCE//.bats/}")"
-  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" -h
+@test "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1).sh -h" {
+  expected="Usage: $(basename "$BATS_TEST_FILENAME" | cut -d. -f1).sh"
+  run run_docker_binary "$BATS_IMAGE" "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1).sh" -h
   [ "$status" -eq 0 ]
   printf '%s' "$output" | grep -Eq "$expected"
 }

--- a/test/yamllint.bats
+++ b/test/yamllint.bats
@@ -3,9 +3,9 @@ set -eu
 
 load .env
 
-@test "$(basename "${BATS_SOURCE//.bats/}") --version" {
+@test "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1) --version" {
   expected="yamllint\\s$VERSION_REGEX"
-  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" --version
+  run run_docker_binary "$BATS_IMAGE" "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1)" --version
   [ $status -eq 0 ]
   printf '%s' "$output" | grep -Eq "$expected"
 }

--- a/test/yamllint.bats
+++ b/test/yamllint.bats
@@ -4,8 +4,8 @@ set -eu
 load .env
 
 @test "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1) --version" {
-  expected="yamllint.*$VERSION_REGEX"
+  expected="yamllint\\s+$VERSION_REGEX"
   run run_docker_binary "$BATS_IMAGE" "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1)" --version
   [ $status -eq 0 ]
-  printf '%s' "$output" | grep -Eq "$expected"
+  printf '%s' "$output" | grep -zEq "$expected"
 }

--- a/test/yamllint.bats
+++ b/test/yamllint.bats
@@ -4,7 +4,7 @@ set -eu
 load .env
 
 @test "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1) --version" {
-  expected="yamllint\\s+$VERSION_REGEX"
+  expected="yamllint.*$VERSION_REGEX"
   run run_docker_binary "$BATS_IMAGE" "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1)" --version
   [ $status -eq 0 ]
   printf '%s' "$output" | grep -Eq "$expected"

--- a/test/yamllint.bats
+++ b/test/yamllint.bats
@@ -4,7 +4,7 @@ set -eu
 load .env
 
 @test "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1) --version" {
-  expected="yamllint\\s$VERSION_REGEX"
+  expected="yamllint\\s+$VERSION_REGEX"
   run run_docker_binary "$BATS_IMAGE" "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1)" --version
   [ $status -eq 0 ]
   printf '%s' "$output" | grep -Eq "$expected"

--- a/test/yq.bats
+++ b/test/yq.bats
@@ -3,9 +3,9 @@ set -eu
 
 load .env
 
-@test "$(basename "${BATS_SOURCE//.bats/}") --version" {
+@test "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1) --version" {
   expected="yq\\s$VERSION_REGEX"
-  run run_docker_binary "$BATS_IMAGE" "$(basename "${BATS_SOURCE//.bats/}")" --version
+  run run_docker_binary "$BATS_IMAGE" "$(basename "$BATS_TEST_FILENAME" | cut -d. -f1)" --version
   [ $status -eq 0 ]
   printf '%s' "$output" | grep -Eq "$expected"
 }


### PR DESCRIPTION
* To trigger a new build, latest should also fetch this version, but
* Pinning is better to have control over when a new base is used, as
that can break things.

We need this to get python3 in the builder.