### PR TITLE
Remove v prefix from base versions

### DIFF
--- a/src/bin/changelog.sh
+++ b/src/bin/changelog.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -eo pipefail
 
 if [ -z "$1" ]; then
   echo "Version tag is missing"
   exit 1
 fi
 
-VERSION="$1"
+# Assign version and strip "v" prefix
+VERSION="${1#v}"
 
 now="$(date +'%Y-%m-%d')"
 contributor_memo=""


### PR DESCRIPTION
This is needed because we know pick up the latest tag of the base repo, instead of the version on the composer file, which has a "v" prefix.

Remove -u from set, since we already have a check.