### PR TITLE
Create a p4 python lib to abstract shared python functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Dockerfile
 test/logs/
+__pycache__

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -34,6 +34,8 @@ RUN git config --global alias.unstaged 'diff --name-only' && \
 
 WORKDIR /home/${CIRCLECI_USER}
 
+COPY --chown=${CIRCLECI_USER}:${CIRCLECI_USER} lib/ /usr/lib/python3.8/
+
 COPY --chown=${CIRCLECI_USER}:${CIRCLECI_USER} .curlrc /home/${CIRCLECI_USER}
 
 USER ${CIRCLECI_USER}

--- a/src/bin/post-comment-to-pr.py
+++ b/src/bin/post-comment-to-pr.py
@@ -2,80 +2,11 @@
 
 import argparse
 from datetime import datetime
-import json
 import os
-import re
-import requests
 
-GITHUB_API = 'https://api.github.com'
+from p4.github import get_pull_request, check_for_comment, post_pr_comment
+
 TEST_INSTANCE_PREFIX = 'https://www-dev.greenpeace.org/test-'
-
-
-def get_pull_request(pr_url):
-    """
-    Creates API endpoint for a give PR url
-    """
-
-    regex = re.compile('https://github.com/(.*)/pull/([0-9]{1,6})')
-    matches = regex.match(pr_url)
-    print('Parsing URL {0}'.format(matches.groups()))
-
-    repository = matches.group(1) or None
-    pr_number = matches.group(2) or None
-
-    if not repository or not pr_number:
-        raise Exception('PR id could not be parsed.')
-
-    pr_endpoint = '{0}/repos/{1}/issues/{2}/comments'.format(
-        GITHUB_API,
-        repository,
-        pr_number
-    )
-
-    comments_endpoint = '{0}/repos/{1}/issues/comments/'.format(
-        GITHUB_API,
-        repository
-    )
-
-    return pr_endpoint, comments_endpoint
-
-
-def check_for_comment(pr_endpoint, title):
-    oauth_key = os.getenv('GITHUB_OAUTH_TOKEN')
-
-    headers = {
-        'Authorization': 'token {0}'.format(oauth_key),
-        'Accept': 'application/vnd.github.v3+json'
-    }
-
-    response = requests.get(pr_endpoint, headers=headers)
-
-    for comment in response.json():
-        if comment['body'].splitlines()[0] == title:
-            return comment['id']
-
-    return False
-
-
-def post_comment(pr_endpoint, comment_endpoint, comment_id, body):
-    oauth_key = os.getenv('GITHUB_OAUTH_TOKEN')
-
-    data = {
-        'body': body
-    }
-    headers = {
-        'Authorization': 'token {0}'.format(oauth_key),
-        'Accept': 'application/vnd.github.v3+json'
-    }
-
-    if comment_id:
-        endpoint = '{0}{1}'.format(comment_endpoint, comment_id)
-        print(endpoint)
-        response = requests.patch(endpoint, headers=headers, data=json.dumps(data))
-        return response.json()
-
-    response = requests.post(pr_endpoint, headers=headers, data=json.dumps(data))
-    return response.json()
 
 
 if __name__ == '__main__':
@@ -106,5 +37,6 @@ if __name__ == '__main__':
     # Post comment, but only once
     comment_id = check_for_comment(pr_endpoint, title)
     # if not exists:
-    response = post_comment(pr_endpoint, comments_endpoint, comment_id, body)
+    response = post_pr_comment(pr_endpoint, comments_endpoint, comment_id, body)
     print(response)
+

--- a/src/lib/p4/apis.py
+++ b/src/lib/p4/apis.py
@@ -1,0 +1,41 @@
+import hashlib
+import json
+import os
+import requests
+
+
+def api_query(url, headers={'Accept': 'application/json'}, auth=None, use_request_cache=True):
+    """
+    Queries API
+    - fails on error
+    - return json
+    - use cache if requested
+    """
+
+    cache_file = '/tmp/{0}.cache'.format(hashlib.md5(url.encode()).hexdigest())
+    if use_request_cache and os.path.isfile(cache_file):
+        return json.load(open(cache_file))
+
+    response = requests.get(url, headers=headers, auth=auth)
+    api_failed(response, url)
+
+    content = response.json()
+
+    json.dump(content, open(cache_file, "w"))  # write anyway
+    return content
+
+
+def api_failed(response, endpoint, exit_on_error=True):
+    """
+    Check if api request failed
+
+    Can raise exception
+    """
+
+    if 200 <= response.status_code < 300:
+        return False
+
+    if exit_on_error:
+        raise Exception("Status code {0} calling {1}".format(
+            response.status_code, endpoint))
+    return True

--- a/src/lib/p4/github.py
+++ b/src/lib/p4/github.py
@@ -1,0 +1,86 @@
+import json
+import os
+import re
+import requests
+
+from p4.apis import api_query
+
+
+GITHUB_API = 'https://api.github.com'
+
+
+def get_pull_request(pr_url):
+    """
+    Creates API endpoint for a give PR url
+    """
+
+    regex = re.compile('https://github.com/(.*)/pull/([0-9]{1,6})')
+    matches = regex.match(pr_url)
+
+    repository = matches.group(1) or None
+    pr_number = matches.group(2) or None
+
+    if not repository or not pr_number:
+        raise Exception('PR id could not be parsed.')
+
+    pr_endpoint = '{0}/repos/{1}/issues/{2}/comments'.format(
+        GITHUB_API,
+        repository,
+        pr_number
+    )
+
+    comments_endpoint = '{0}/repos/{1}/issues/comments/'.format(
+        GITHUB_API,
+        repository
+    )
+
+    return pr_endpoint, comments_endpoint
+
+
+def check_for_comment(pr_endpoint, title):
+    oauth_key = os.getenv('GITHUB_OAUTH_TOKEN')
+
+    headers = {
+        'Authorization': 'token {0}'.format(oauth_key),
+        'Accept': 'application/vnd.github.v3+json'
+    }
+
+    response = requests.get(pr_endpoint, headers=headers)
+
+    for comment in response.json():
+        if comment['body'].splitlines()[0] == title:
+            return comment['id']
+
+    return False
+
+
+def get_last_commit_date(repo):
+    """
+    Return last commit date for a repo.
+    """
+    commit = api_query(
+        GITHUB_API + '/repos/' + repo + '/commits/main',
+        {'Accept': 'application/vnd.github.v3+json'}
+    )
+
+    return commit['commit']['committer']['date']
+
+
+def post_pr_comment(pr_endpoint, comment_endpoint, comment_id, body):
+    oauth_key = os.getenv('GITHUB_OAUTH_TOKEN')
+
+    data = {
+        'body': body
+    }
+    headers = {
+        'Authorization': 'token {0}'.format(oauth_key),
+        'Accept': 'application/vnd.github.v3+json'
+    }
+
+    if comment_id:
+        endpoint = '{0}{1}'.format(comment_endpoint, comment_id)
+        response = requests.patch(endpoint, headers=headers, data=json.dumps(data))
+        return response.json()
+
+    response = requests.post(pr_endpoint, headers=headers, data=json.dumps(data))
+    return response.json()


### PR DESCRIPTION
This adds a p4 libs folder inside the python path (see change in the Dockerfile template).

As a start, this moves shared api and github functions and removes them from the main python scripts.

Other changes:
* Substituted the custom `vprint` method with `print` to make it easier to abstract things, but if we see a value
on storing an artifacts file with all the logs we can figure out a way later that can be re-used by all the python scripts.
* Made `get_pull_request` also return comments endpoint, for cases where we want to post a comment on a PR.
* `get_instance_last_commit_date` renamed to `get_last_commit_date` in order to have a more generic scope.