### PR TITLE
Delete previous comment, always post new

### DIFF
--- a/src/bin/post-comment-to-pr.py
+++ b/src/bin/post-comment-to-pr.py
@@ -71,8 +71,7 @@ def post_comment(pr_endpoint, comment_endpoint, comment_id, body):
     if comment_id:
         endpoint = '{0}{1}'.format(comment_endpoint, comment_id)
         print(endpoint)
-        response = requests.patch(endpoint, headers=headers, data=json.dumps(data))
-        return response.json()
+        requests.delete(endpoint, headers=headers)
 
     response = requests.post(pr_endpoint, headers=headers, data=json.dumps(data))
     return response.json()


### PR DESCRIPTION
That way we always get notified of a deploy, Toast doesn't send a Slack message on comment updates.

As a bonus, it's also nicer to have the comment at the bottom, which is a more predictable location, right after the deployed commit and before the GitHub Checks results.

Tested on https://github.com/greenpeace/planet4-master-theme/pull/1374, feel free to push a commit to that PR if you want to test.