### PR TITLE
Add function for adding PR labels

### DIFF
--- a/src/bin/book-test-instance.py
+++ b/src/bin/book-test-instance.py
@@ -14,7 +14,7 @@ from requests.auth import HTTPBasicAuth
 from requests_oauthlib import OAuth1
 
 from p4.apis import api_failed, api_query
-from p4.github import get_last_commit_date, get_pull_request
+from p4.github import get_last_commit_date, get_repo_endpoints, get_pr_test_instance
 
 JIRA_API = 'https://jira.greenpeace.org/rest/api/2'
 GITHUB_API = 'https://api.github.com'
@@ -293,7 +293,7 @@ if __name__ == '__main__':
         logs.append('## Dry run, nothing will be commited.')
 
     # Fetch PR details
-    pr_endpoint, _ = get_pull_request(pr_url=pr_url)
+    pr_endpoint, _ = get_repo_endpoints(pr_url=pr_url)
     if not pr_endpoint:
         raise Exception('No pull request found, aborting.')
 
@@ -305,7 +305,9 @@ if __name__ == '__main__':
     # If not a ticket PR just get an available instance
     # Reverse the order to avoid race condition
     if not issue:
-        instance = get_available_instance(randomize=True)
+        instance = get_pr_test_instance(pr_endpoint)
+        if not instance:
+            instance = get_available_instance(randomize=True)
     else:
         # Use pre-booked instance or get a new one
         if issue['test_instance']:

--- a/src/bin/post-comment-to-pr.py
+++ b/src/bin/post-comment-to-pr.py
@@ -4,7 +4,8 @@ import argparse
 from datetime import datetime
 import os
 
-from p4.github import get_pull_request, check_for_comment, post_pr_comment
+from p4.github import (get_repo_endpoints, check_for_comment,
+                       post_issue_comment, add_issue_label)
 
 TEST_INSTANCE_PREFIX = 'https://www-dev.greenpeace.org/test-'
 
@@ -24,7 +25,7 @@ if __name__ == '__main__':
     test_instance = args.test_instance
 
     # Fetch PR details
-    pr_endpoint, comments_endpoint = get_pull_request(pr_url=pr_url)
+    pr_endpoint, comment_endpoint = get_repo_endpoints(pr_url=pr_url)
 
     # Construct comment body
     now = datetime.now().strftime('%Y.%m.%d %H:%M:%S')
@@ -36,7 +37,11 @@ if __name__ == '__main__':
 
     # Post comment, but only once
     comment_id = check_for_comment(pr_endpoint, title)
-    # if not exists:
-    response = post_pr_comment(pr_endpoint, comments_endpoint, comment_id, body)
-    print(response)
+    post_issue_comment(pr_endpoint, comment_endpoint, comment_id, body)
+
+    # Add label
+    label_name = '[Test Env] {0}'.format(test_instance)
+    add_issue_label(pr_endpoint, label_name)
+
+    print("Comment posted")
 

--- a/src/lib/p4/github.py
+++ b/src/lib/p4/github.py
@@ -9,7 +9,7 @@ from p4.apis import api_query
 GITHUB_API = 'https://api.github.com'
 
 
-def get_pull_request(pr_url):
+def get_repo_endpoints(pr_url):
     """
     Creates API endpoint for a give PR url
     """
@@ -29,13 +29,12 @@ def get_pull_request(pr_url):
         pr_number
     )
 
-    comments_endpoint = '{0}/repos/{1}/issues/{2}/comments/'.format(
+    comment_endpoint = '{0}/repos/{1}/issues/comments/'.format(
         GITHUB_API,
-        repository,
-        pr_number
+        repository
     )
 
-    return pr_endpoint, comments_endpoint
+    return pr_endpoint, comment_endpoint
 
 
 def check_for_comment(pr_endpoint, title):
@@ -46,7 +45,9 @@ def check_for_comment(pr_endpoint, title):
         'Accept': 'application/vnd.github.v3+json'
     }
 
-    response = requests.get(pr_endpoint, headers=headers)
+    comments_endpoint = '{0}/comments'.format(pr_endpoint)
+
+    response = requests.get(comments_endpoint, headers=headers)
 
     for comment in response.json():
         if comment['body'].splitlines()[0] == title:
@@ -67,7 +68,7 @@ def get_last_commit_date(repo):
     return commit['commit']['committer']['date']
 
 
-def post_pr_comment(pr_endpoint, comment_endpoint, comment_id, body):
+def post_issue_comment(pr_endpoint, comment_endpoint, comment_id, body):
     oauth_key = os.getenv('GITHUB_OAUTH_TOKEN')
 
     data = {
@@ -78,10 +79,48 @@ def post_pr_comment(pr_endpoint, comment_endpoint, comment_id, body):
         'Accept': 'application/vnd.github.v3+json'
     }
 
+    comments_endpoint = '{0}/comments'.format(pr_endpoint)
+
     if comment_id:
         endpoint = '{0}{1}'.format(comment_endpoint, comment_id)
         response = requests.patch(endpoint, headers=headers, data=json.dumps(data))
         return response.json()
 
-    response = requests.post(pr_endpoint, headers=headers, data=json.dumps(data))
+    response = requests.post(comments_endpoint, headers=headers, data=json.dumps(data))
     return response.json()
+
+
+def add_issue_label(pr_endpoint, label_name):
+    oauth_key = os.getenv('GITHUB_OAUTH_TOKEN')
+
+    data = {
+        'labels': [label_name]
+    }
+    headers = {
+        'Authorization': 'token {0}'.format(oauth_key),
+        'Accept': 'application/vnd.github.v3+json'
+    }
+
+    labels_endpoint = '{0}/labels'.format(pr_endpoint)
+
+    response = requests.post(labels_endpoint, headers=headers, data=json.dumps(data))
+    return response.json()
+
+
+def get_pr_test_instance(pr_endpoint, prefix='[Test Env] '):
+    oauth_key = os.getenv('GITHUB_OAUTH_TOKEN')
+
+    headers = {
+        'Authorization': 'token {0}'.format(oauth_key),
+        'Accept': 'application/vnd.github.v3+json'
+    }
+
+    response = requests.get(pr_endpoint, headers=headers)
+
+    labels = response.json()['labels']
+
+    for label in labels:
+        if label['name'].startswith(prefix):
+            return label['name'][len(prefix):]
+
+    return False


### PR DESCRIPTION
This can be used in the [swarm repo](https://github.com/greenpeace/planet4-test-swarm/pull/2) to determine which test instance is in use even when there is no ticket.

**Additionally:**
- Renamed `get_pull_request` to `get_repo_endpoints` to make it more accurate of what it actually does.
- Amended `get_repo_endpoints` to only return the endpoints we can't construct from pr_endpoint.

**Testing**
I created this [draft PR](https://github.com/greenpeace/planet4-master-theme/pull/1418), which has no ticket number. When a test instance is being used it adds a label in the form of `[Test Env] <test-instance>`. Every time the pipeline runs again, it reads the label and uses the same instance. 