### PR TITLE
Exclude instances used by non-ticket PR and add label earlier

### DIFF
--- a/src/bin/book-test-instance.py
+++ b/src/bin/book-test-instance.py
@@ -14,7 +14,7 @@ from requests.auth import HTTPBasicAuth
 from requests_oauthlib import OAuth1
 
 from p4.apis import api_failed, api_query
-from p4.github import get_last_commit_date, get_repo_endpoints, get_pr_test_instance
+from p4.github import get_last_commit_date, get_repo_endpoints, get_pr_test_instance, has_open_pr_labeled_with_instance
 
 JIRA_API = 'https://jira.greenpeace.org/rest/api/2'
 GITHUB_API = 'https://api.github.com'
@@ -193,8 +193,12 @@ def get_available_instance(randomize=False):
         random.shuffle(available_list)
         return available_list[0]
 
+    not_used_with_label = list(filter(lambda name: has_open_pr_labeled_with_instance(name), available_list))
+    print(available_list)
+    print(not_used_with_label)
+
     dated_list = list(
-        map(lambda name: [name, get_last_commit_date(INSTANCE_REPO_PREFIX + name)], available_list))
+        map(lambda name: [name, get_last_commit_date(INSTANCE_REPO_PREFIX + name)], not_used_with_label))
 
     dated_list.sort(key=lambda i: i[1])
 

--- a/src/bin/book-test-instance.py
+++ b/src/bin/book-test-instance.py
@@ -7,14 +7,13 @@ import hashlib
 import json
 from oauthlib.oauth1 import SIGNATURE_RSA
 import os
-import random
 import re
 import requests
 from requests.auth import HTTPBasicAuth
 from requests_oauthlib import OAuth1
 
 from p4.apis import api_failed, api_query
-from p4.github import get_last_commit_date, get_repo_endpoints, get_pr_test_instance, has_open_pr_labeled_with_instance
+from p4.github import get_last_commit_date, get_repo_endpoints, get_pr_test_instance, has_open_pr_labeled_with_instance, add_issue_label
 
 JIRA_API = 'https://jira.greenpeace.org/rest/api/2'
 GITHUB_API = 'https://api.github.com'
@@ -176,7 +175,7 @@ Instances
 """
 
 
-def get_available_instance(randomize=False):
+def get_available_instance():
     """
     fetch instances from swarm | filter available
     fetch last commit date on each, reverse order for a steady rotation
@@ -189,13 +188,7 @@ def get_available_instance(randomize=False):
     if not len(available_list):
         raise Exception('No available instance could be found.')
 
-    if randomize:
-        random.shuffle(available_list)
-        return available_list[0]
-
-    not_used_with_label = list(filter(lambda name: has_open_pr_labeled_with_instance(name), available_list))
-    print(available_list)
-    print(not_used_with_label)
+    not_used_with_label = list(filter(lambda name: not has_open_pr_labeled_with_instance(name), available_list))
 
     dated_list = list(
         map(lambda name: [name, get_last_commit_date(INSTANCE_REPO_PREFIX + name)], not_used_with_label))
@@ -310,17 +303,20 @@ if __name__ == '__main__':
     # Reverse the order to avoid race condition
     if not issue:
         instance = get_pr_test_instance(pr_endpoint)
-        if not instance:
-            instance = get_available_instance(randomize=True)
     else:
         # Use pre-booked instance or get a new one
         if issue['test_instance']:
             instance = issue['test_instance']
             logs.append('Issue is already deployed on {0}, reusing.'.format(instance))
-        else:
-            instance = get_available_instance()
 
-        book_instance(instance, issue)
+
+    if not instance:
+        instance = get_available_instance()
+        label_name = '[Test Env] {0}'.format(instance)
+        add_issue_label(pr_endpoint, label_name)
+        if issue:
+            book_instance(instance, issue)
+
 
     if results_file:
         save_results({

--- a/src/bin/post-comment-to-pr.py
+++ b/src/bin/post-comment-to-pr.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import os
 
 from p4.github import (get_repo_endpoints, check_for_comment,
-                       post_issue_comment, add_issue_label)
+                       post_issue_comment)
 
 if __name__ == '__main__':
 
@@ -39,10 +39,6 @@ if __name__ == '__main__':
     # Post comment, but only once
     comment_id = check_for_comment(pr_endpoint, title)
     post_issue_comment(pr_endpoint, comment_endpoint, comment_id, body)
-
-    # Add label
-    label_name = '[Test Env] {0}'.format(test_instance)
-    add_issue_label(pr_endpoint, label_name)
 
     print("Comment posted")
 

--- a/src/lib/p4/github.py
+++ b/src/lib/p4/github.py
@@ -104,3 +104,15 @@ def get_pr_test_instance(pr_endpoint, prefix='[Test Env] '):
             return label['name'][len(prefix):]
 
     return False
+
+def has_open_pr_labeled_with_instance(name):
+    BLOCKS_ENDPOINT = 'https://api.github.com/repos/greenpeace/planet4-plugin-gutenberg-blocks/issues?state=open&labels=env-test-{0}'
+    THEME_ENDPOINT = 'https://api.github.com/repos/greenpeace/planet4-master-theme/issues?state=open&labels=env-test-{0}'
+
+    blocks_prs = api_query(BLOCKS_ENDPOINT.format(name), get_headers());
+    if len(blocks_prs) > 0:
+        return true
+
+    theme_prs = api_query(THEME_ENDPOINT.format(name), get_headers());
+
+    return len(theme_prs) > 0

--- a/src/lib/p4/github.py
+++ b/src/lib/p4/github.py
@@ -106,13 +106,13 @@ def get_pr_test_instance(pr_endpoint, prefix='[Test Env] '):
     return False
 
 def has_open_pr_labeled_with_instance(name):
-    BLOCKS_ENDPOINT = 'https://api.github.com/repos/greenpeace/planet4-plugin-gutenberg-blocks/issues?state=open&labels=env-test-{0}'
-    THEME_ENDPOINT = 'https://api.github.com/repos/greenpeace/planet4-master-theme/issues?state=open&labels=env-test-{0}'
+    BLOCKS_ENDPOINT = 'https://api.github.com/repos/greenpeace/planet4-plugin-gutenberg-blocks/issues?state=open&labels=[Test Env] {0}'
+    THEME_ENDPOINT = 'https://api.github.com/repos/greenpeace/planet4-master-theme/issues?state=open&labels=[Test Env] {0}'
 
-    blocks_prs = api_query(BLOCKS_ENDPOINT.format(name), get_headers());
+    blocks_prs = api_query(BLOCKS_ENDPOINT.format(name), get_headers())
     if len(blocks_prs) > 0:
-        return true
+        return True
 
-    theme_prs = api_query(THEME_ENDPOINT.format(name), get_headers());
+    theme_prs = api_query(THEME_ENDPOINT.format(name), get_headers())
 
     return len(theme_prs) > 0

--- a/src/lib/p4/github.py
+++ b/src/lib/p4/github.py
@@ -8,6 +8,14 @@ from p4.apis import api_query
 
 GITHUB_API = 'https://api.github.com'
 
+def get_headers():
+    oauth_key = os.getenv('GITHUB_OAUTH_TOKEN')
+
+    return {
+        'Authorization': 'token {0}'.format(oauth_key),
+        'Accept': 'application/vnd.github.v3+json'
+    }
+
 
 def get_repo_endpoints(pr_url):
     """
@@ -38,16 +46,9 @@ def get_repo_endpoints(pr_url):
 
 
 def check_for_comment(pr_endpoint, title):
-    oauth_key = os.getenv('GITHUB_OAUTH_TOKEN')
-
-    headers = {
-        'Authorization': 'token {0}'.format(oauth_key),
-        'Accept': 'application/vnd.github.v3+json'
-    }
-
     comments_endpoint = '{0}/comments'.format(pr_endpoint)
 
-    response = requests.get(comments_endpoint, headers=headers)
+    response = requests.get(comments_endpoint, headers=get_headers())
 
     for comment in response.json():
         if comment['body'].splitlines()[0] == title:
@@ -69,53 +70,32 @@ def get_last_commit_date(repo):
 
 
 def post_issue_comment(pr_endpoint, comment_endpoint, comment_id, body):
-    oauth_key = os.getenv('GITHUB_OAUTH_TOKEN')
-
     data = {
         'body': body
     }
-    headers = {
-        'Authorization': 'token {0}'.format(oauth_key),
-        'Accept': 'application/vnd.github.v3+json'
-    }
-
     comments_endpoint = '{0}/comments'.format(pr_endpoint)
 
     if comment_id:
         endpoint = '{0}{1}'.format(comment_endpoint, comment_id)
-        response = requests.patch(endpoint, headers=headers, data=json.dumps(data))
+        response = requests.patch(endpoint, headers=get_headers(), data=json.dumps(data))
         return response.json()
 
-    response = requests.post(comments_endpoint, headers=headers, data=json.dumps(data))
+    response = requests.post(comments_endpoint, headers=get_headers(), data=json.dumps(data))
     return response.json()
 
 
 def add_issue_label(pr_endpoint, label_name):
-    oauth_key = os.getenv('GITHUB_OAUTH_TOKEN')
-
     data = {
         'labels': [label_name]
     }
-    headers = {
-        'Authorization': 'token {0}'.format(oauth_key),
-        'Accept': 'application/vnd.github.v3+json'
-    }
-
     labels_endpoint = '{0}/labels'.format(pr_endpoint)
 
-    response = requests.post(labels_endpoint, headers=headers, data=json.dumps(data))
+    response = requests.post(labels_endpoint, headers=get_headers(), data=json.dumps(data))
     return response.json()
 
 
 def get_pr_test_instance(pr_endpoint, prefix='[Test Env] '):
-    oauth_key = os.getenv('GITHUB_OAUTH_TOKEN')
-
-    headers = {
-        'Authorization': 'token {0}'.format(oauth_key),
-        'Accept': 'application/vnd.github.v3+json'
-    }
-
-    response = requests.get(pr_endpoint, headers=headers)
+    response = requests.get(pr_endpoint, headers=get_headers())
 
     labels = response.json()['labels']
 


### PR DESCRIPTION
Tested on https://github.com/greenpeace/planet4-master-theme/pull/1423

I started the branch just for moving the label addition. Then I noticed the check for labels would not be too hard to add. This prevents a few things like mentioned in [this comment](https://github.com/greenpeace/planet4-circleci/pull/54#discussion_r677378521).

I also moved the code to get authenticated headers into a function.