### PR TITLE
Add pull request link to test instance deployment commit message

### DIFF
--- a/src/bin/trigger_test_instance.sh
+++ b/src/bin/trigger_test_instance.sh
@@ -51,7 +51,7 @@ git -C "$instance_repo" --no-pager diff
 git -C "$instance_repo" add composer-local.json
 
 git -C "$instance_repo" commit --allow-empty \
-  -m "$CIRCLE_PROJECT_REPONAME at branch $CIRCLE_BRANCH, commit $CIRCLE_SHA1" \
+  -m "$CIRCLE_PULL_REQUEST at ${CIRCLE_SHA1:0:8}" \
   -m "/unhold $CIRCLE_WORKFLOW_ID"
 
 git -C "$instance_repo" push


### PR DESCRIPTION
Otherwise there is no clickable link to what caused the commit on the test instance.

I added the link to the first line, because that makes it show up on the repo root page of the instance. It's also nice in the [history view](https://github.com/greenpeace/planet4-test-titan/commits/main).

Testing on https://github.com/greenpeace/planet4-master-theme/pull/1425