### PR TITLE
Default to repo name

### DIFF
--- a/src/bin/trigger_test_instance.sh
+++ b/src/bin/trigger_test_instance.sh
@@ -51,7 +51,7 @@ git -C "$instance_repo" --no-pager diff
 git -C "$instance_repo" add composer-local.json
 
 git -C "$instance_repo" commit --allow-empty \
-  -m "$CIRCLE_PULL_REQUEST at ${CIRCLE_SHA1:0:8}" \
+  -m "${CIRCLE_PULL_REQUEST:-$CIRCLE_PROJECT_REPONAME} at ${CIRCLE_SHA1:0:8}" \
   -m "/unhold $CIRCLE_WORKFLOW_ID"
 
 git -C "$instance_repo" push


### PR DESCRIPTION
Otherwise it has an unbound variable for merge commits, where it's not running for a pull request.

For example https://app.circleci.com/pipelines/github/greenpeace/planet4-master-theme/3617/workflows/585f37d9-d982-42b2-9e73-17e8a3a5fddd/jobs/19785