### PR TITLE
Fix booking failing on issue status transition

### DIFF
--- a/src/bin/book-test-instance.py
+++ b/src/bin/book-test-instance.py
@@ -136,7 +136,7 @@ def transition_issue(jira_issue):
                              })
 
     logs.append('Transitioned issue, response: ')
-    logs.append(response.status_code, response.headers, response.text)
+    logs.extend([response.status_code, response.headers, response.text])
 
     failed = api_failed(response, transition_endpoint, exit_on_error=False)
     if failed:


### PR DESCRIPTION
A `log.append` makes the booking fail when the issue has to transition its status to "in development".
The transition works, and another attempt will succeed because it won't pass through the same bit of code.

Cf https://app.circleci.com/pipelines/github/greenpeace/planet4-master-theme/4193/workflows/a24fb5ae-b167-45df-82e9-c59f8657b696/jobs/24234
`TypeError: append() takes exactly one argument (3 given)`