### PR TITLE
Add logging to see why instance can't be found

### DIFF
--- a/src/bin/book-test-instance.py
+++ b/src/bin/book-test-instance.py
@@ -190,8 +190,11 @@ def get_available_instance():
     if not len(available_list):
         raise Exception('No available instance could be found.')
 
-    not_used_with_label = list(filter(lambda name: not has_open_pr_labeled_with_instance(name),
-                                      available_list))
+    not_used_with_label = list(
+        filter(
+            lambda name: not has_open_pr_labeled_with_instance(name, logs),
+            available_list
+        ))
 
     dated_list = list(
         map(lambda name: [name, get_last_commit_date(INSTANCE_REPO_PREFIX + name)],

--- a/src/bin/book-test-instance.py
+++ b/src/bin/book-test-instance.py
@@ -183,6 +183,7 @@ def get_available_instance():
     return oldest available instance
     """
     instances = get_instances()
+    logs.append('Swarm response {0}'.format(json.dumps(instances, indent=4)))
 
     available_list = list(filter(lambda name: instances[name] == 1, instances))
 
@@ -197,6 +198,9 @@ def get_available_instance():
             not_used_with_label))
 
     dated_list.sort(key=lambda i: i[1])
+
+    if not len(dated_list):
+        raise Exception('No available instance after checking Github labels.')
 
     return dated_list[0][0]
 

--- a/src/lib/p4/github.py
+++ b/src/lib/p4/github.py
@@ -107,7 +107,7 @@ def get_pr_test_instance(pr_endpoint, prefix='[Test Env] '):
     return False
 
 
-def has_open_pr_labeled_with_instance(name):
+def has_open_pr_labeled_with_instance(name, logs):
     BLOCKS_ENDPOINT = ('{0}/repos/greenpeace/planet4-plugin-gutenberg-blocks/'
                        'issues?state=open&labels=[Test Env] ').format(GITHUB_API)
     THEME_ENDPOINT = ('{0}/repos/greenpeace/planet4-master-theme/'

--- a/src/lib/p4/github.py
+++ b/src/lib/p4/github.py
@@ -113,10 +113,14 @@ def has_open_pr_labeled_with_instance(name):
     THEME_ENDPOINT = ('{0}/repos/greenpeace/planet4-master-theme/'
                       'issues?state=open&labels=[Test Env] ').format(GITHUB_API)
 
+    logs.append('Checking Github labels for: {0}'.format(name))
     blocks_prs = api_query('{0}{1}'.format(BLOCKS_ENDPOINT, name), _get_headers())
     if len(blocks_prs) > 0:
+        logs.append('Plugin: {0}'.format(json.dumps(blocks_prs, indent=4)))
         return True
 
     theme_prs = api_query(THEME_ENDPOINT.format(name), _get_headers())
+    if len(blocks_prs) > 0:
+        logs.append('Theme: {0}\n{1}'.format(name, json.dumps(theme_prs, indent=4)))
 
     return len(theme_prs) > 0


### PR DESCRIPTION
* Previously it would crash trying to access the first element of an
empty array. Make it use a nicer error message instead.
* Dump JSON a few times to see what's happening.

Example of failing workflow: https://app.circleci.com/pipelines/github/greenpeace/planet4-master-theme/5488/workflows/a1bfb3e2-3acd-48a7-a8c5-524306142b2f/jobs/33751