### PR TITLE
Get highest semantic tag instead of latest, to avoid build lock

### DIFF
--- a/src/bin/trigger-build.sh
+++ b/src/bin/trigger-build.sh
@@ -29,7 +29,7 @@ if [ "$branch" == "main" ]; then
   git commit --allow-empty -m ":robot:${GIT_PREFIX} Trigger build #${CIRCLE_BUILD_NUM}" -m "${CIRCLE_BUILD_URL}"
   git push origin "$branch"
 else
-  current_version=$(git describe --abbrev=0 --tags)
+  current_version=$(git tag --sort=-v:refname | head -1)
   new_version=$(increment-version.sh "$current_version")
   git tag -a "$new_version" -m "$new_version"
   git push origin --tags


### PR DESCRIPTION
If tags are created manually in the wrong order, it blocks the build system.
The scripts ends up not being able to commit a tag that already exists.

This currently happens for Japan (v1.170 created after v1.171) and Taiwan (2 tags created at the same time)

Cf [base pipeline](https://app.circleci.com/pipelines/github/greenpeace/planet4-base/1675/workflows/e0d0f27c-54e5-490d-be3e-05a5a59f1a17/jobs/8163)
![Screenshot from 2022-09-13 09-05-46](https://user-images.githubusercontent.com/617346/189833449-b6407a36-e754-4851-b90a-aa9f4bcf3a22.png)


## Test

Create some tags and test those commands on a repo.  
Example on [Japan repo](https://github.com/greenpeace/planet4-japan/tags) where `v1.170` was manually created after `v1.171` (before the latest manual deployment)
```console
> git describe --abbrev=0 --tags
v1.170

> git tag --sort=-v:refname | head -1
v1.171
```
