### PR TITLE
Check branch name for reseting test instances

### DIFF
--- a/src/bin/check-pr-exists.sh
+++ b/src/bin/check-pr-exists.sh
@@ -1,15 +1,11 @@
 #!/bin/bash
 set -eo pipefail
 
-commit_msg="$1"
-
-# Check if this is a merge commit first, which means this triggered by a merged PR.
-# We use that check to reset the test instance.
+# Check if this is runs in the main branch. We use that check to reset the test instance.
 # Otherwise it's either a normal PR or just a new commit that doesn't require deployment.
-if [[ "$commit_msg" =~ ^Merge[[:space:]]pull[[:space:]]request[[:space:]]\#([[:digit:]]+) ]]; then
-  echo "https://github.com/greenpeace/${CIRCLE_PROJECT_REPONAME}/pull/${BASH_REMATCH[1]}" >/tmp/workspace/pr
-  echo "MERGED PR ID: ${BASH_REMATCH[1]}"
+if [[ "$CIRCLE_BRANCH" = "main" ]]; then
   echo true >/tmp/workspace/is_merge_commit
+  echo "$CIRCLE_PULL_REQUEST" >/tmp/workspace/pr
 else
   if [ -z "$CIRCLE_PULL_REQUEST" ]; then
     echo "No PR found, skipping instance deploy"

--- a/src/bin/trigger_test_instance.sh
+++ b/src/bin/trigger_test_instance.sh
@@ -26,7 +26,7 @@ get_other_repos=".repositories // [] | map(select( .package.name != \"greenpeace
 other_repos=$(jq "$get_other_repos" <"$composer_file")
 
 if [ "$is_merge_commit" == true ]; then
-  # If the workflow is running for a merge commit, we set the version to the branch that was merged to (main mostly).
+  # If the workflow is running on the main branch, we set the version to the branch that was merged to.
   version="dev-$CIRCLE_BRANCH"
   package_repo=""
 else


### PR DESCRIPTION
Since we stopped doing merge commits our previous check doesn't work anymore. 
We can just use `$CIRCLE_BRANCH` to determine if the pipeline runs on the main branch.