### PR TITLE
Enable gcloud update

### DIFF
--- a/src/bin/activate-gcloud-account.sh
+++ b/src/bin/activate-gcloud-account.sh
@@ -12,7 +12,7 @@ if [[ -z "${GOOGLE_PROJECT_ID}" ]]; then
 fi
 
 # Update gcloud sdk components
-# gcloud --quiet components update
+gcloud --quiet components update
 
 # Decode base64-encoded service key json
 echo "${GCLOUD_SERVICE_KEY}" | base64 --decode -i >"${HOME}/gcloud-service-key.json"


### PR DESCRIPTION
Enable update to avoid pipeline errors:
```
error: The gcp auth plugin has been removed.
Please use the "gke-gcloud-auth-plugin" kubectl/client-go credential plugin instead
```